### PR TITLE
Add --keep, dep on newer twine

### DIFF
--- a/squatter/__main__.py
+++ b/squatter/__main__.py
@@ -12,9 +12,7 @@ def cli() -> None:  # pragma: no cover
 
 
 @cli.command(help="Generate a package")
-@click.option(
-    "--keep", is_flag=True, default=False, help="Do not delete temp dir"
-)
+@click.option("--keep", is_flag=True, default=False, help="Do not delete temp dir")
 @click.option(
     "--upload", is_flag=True, default=False, help="Whether to invoke twine upload"
 )
@@ -24,7 +22,11 @@ def cli() -> None:  # pragma: no cover
 )
 @click.argument("package_name")
 def generate(
-    package_name: str, upload: bool, keep: bool, author: Optional[str], author_email: Optional[str]
+    package_name: str,
+    upload: bool,
+    keep: bool,
+    author: Optional[str],
+    author_email: Optional[str],
 ) -> None:
     # TODO flag for delete
     with tempfile.TemporaryDirectory(prefix=package_name, delete=not keep) as d:

--- a/squatter/__main__.py
+++ b/squatter/__main__.py
@@ -13,6 +13,9 @@ def cli() -> None:  # pragma: no cover
 
 @cli.command(help="Generate a package")
 @click.option(
+    "--keep", is_flag=True, default=False, help="Do not delete temp dir"
+)
+@click.option(
     "--upload", is_flag=True, default=False, help="Whether to invoke twine upload"
 )
 @click.option("--author", help="Author name, defaults to reading from git config")
@@ -21,11 +24,13 @@ def cli() -> None:  # pragma: no cover
 )
 @click.argument("package_name")
 def generate(
-    package_name: str, upload: bool, author: Optional[str], author_email: Optional[str]
+    package_name: str, upload: bool, keep: bool, author: Optional[str], author_email: Optional[str]
 ) -> None:
     # TODO flag for delete
-    with tempfile.TemporaryDirectory(prefix=package_name) as d:
+    with tempfile.TemporaryDirectory(prefix=package_name, delete=not keep) as d:
         env = Env(d)
+        if keep:
+            print("Generating in", d)
         env.generate(
             package_name=package_name, author=author, author_email=author_email
         )

--- a/squatter/tests/__init__.py
+++ b/squatter/tests/__init__.py
@@ -1,3 +1,4 @@
+import re
 import tarfile
 import unittest
 from pathlib import Path
@@ -106,3 +107,13 @@ class SquatterEnvTest(unittest.TestCase):
         self.assertEqual("", result.output)
         self.assertFalse(result.exception)
         self.assertEqual(1, uploads)
+
+    @patch("squatter.templates.check_output")
+    @patch("squatter.templates.check_call")
+    def test_cli_keep_flag(self, check_call_mock: Any, check_output_mock: Any) -> None:
+        runner = CliRunner()
+        result = runner.invoke(generate, ["--keep", "foo"])
+        m = re.match("Generating in (.+)", result.output)
+        assert Path(m.group(1)).exists()
+        assert Path(m.group(1), "pyproject.toml")
+        self.assertFalse(result.exception)

--- a/squatter/tests/__init__.py
+++ b/squatter/tests/__init__.py
@@ -114,6 +114,7 @@ class SquatterEnvTest(unittest.TestCase):
         runner = CliRunner()
         result = runner.invoke(generate, ["--keep", "foo"])
         m = re.match("Generating in (.+)", result.output)
+        assert m is not None
         assert Path(m.group(1)).exists()
         assert Path(m.group(1), "pyproject.toml")
         self.assertFalse(result.exception)


### PR DESCRIPTION
Used this recently, some small changes:

* twine 4.x doesn't work on modern python (seems importlib related)
* add --keep to help debug what's going on
* modern python doesn't bundle setuptools (add to dev deps)