### PR TITLE
It's "hatch publish" not "hatch upload"

### DIFF
--- a/squatter/templates.py
+++ b/squatter/templates.py
@@ -52,4 +52,4 @@ class Env:
 
     def upload(self) -> None:
         self.sdist()
-        check_call(["hatch", "upload"], cwd=self.staging_directory)
+        check_call(["hatch", "publish"], cwd=self.staging_directory)

--- a/squatter/tests/__init__.py
+++ b/squatter/tests/__init__.py
@@ -91,7 +91,7 @@ class SquatterEnvTest(unittest.TestCase):
             if cmd[0] != "hatch":
                 return check_call(cmd, **kwargs)
             else:
-                if "upload" in cmd:
+                if "publish" in cmd:
                     uploads += 1
 
         check_call_mock.side_effect = patched_check_call


### PR DESCRIPTION
Also reported some difficulties in
https://github.com/pypa/hatch/issues/1979 where it doesn't seem to default to what's in ~/.pypirc